### PR TITLE
RDKit 2022.09.1 の更新情報を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,6 @@ RDKit のユーザーであれば、どなたでも参加することが可能�
 
 ### Twitter
 - hash_tag: [#rdkitjp](https://twitter.com/search?f=tweets&q=%23rdkitjp)
+
+## ドキュメント
+- [RDKit 2022.09.1 がリリースされました](docs/release-2022-09-1)

--- a/docs/release-2022-09-1.md
+++ b/docs/release-2022-09-1.md
@@ -1,0 +1,74 @@
+# RDKit 2022.09.1 がリリースされました
+2022年10月21日に RDKit 2022.09.1 がリリースされました。この記事では新バージョンのリリースノートの抄訳と新機能のコード例を紹介します。より詳細な情報を知りたい方はリリースノートの原文 ([2022_09_1 (Q3 2022) Release](https://github.com/rdkit/rdkit/releases/tag/Release_2022_09_1)) をご確認ください。
+
+## リリースノート抄訳
+<!-- ## Highlights -->
+### ハイライト
+<!-- - The new RegistrationHash module provides one of the last pieces required to build a registration system with the RDKit. -->
+- RDKitで分子登録システムを構築するために必要な`RegistrationHash`モジュールが追加されました。
+<!-- This release includes an initial version of a C++ implementation of the xyz2mol algorithm for assigning bonds and bond orders based on atomic positions. This work was done as part of the 2022 Google Summer of Code. -->
+- 原子の位置から結合と結合次数を決めるxyz2molアルゴリズムのC++実装の初期バージョンが追加されました。これは2022年のGoogle Summer of Codeの成果です。
+<!-- A collection of new functionality has been added to minimallib and is now accessible from JavaScript and other programming languages. -->
+- minimallibに複数の新機能が追加され、JavaScript等の言語から使用可能になりました。
+
+<!-- ## Backwards incompatible changes -->
+### 後方互換性のない変更
+<!-- Changes to the way atomic chirality is used in the canonicalization algorithm mean that canonical atom ranking and canonical SMILES generated with this RDKit version can be different from those generated with previous versions -->
+- カノニカル化アルゴリズムにおける原子のキラリティーの扱いが変更されため、このRDKitバージョンで生成されるカノニカル原子順位やカノニカルSMILESは以前のバージョンで生成されたものと異なる可能性があります。
+<!-- - `GetBestRMS() and CalcRMS()` by default now treat terminal conjugated functional groups like carboxylate and nitro symmetrically. For example, the group `C(=[O:1])[O-:2]` can match in either orientation. The SMARTS pattern which is used to recognize affected groups is: 
+  `[{atomP};$([{atomP}]-[*]=[{atomP}]),$([{atomP}]=[*]-[{atomP}])]~[*]` where
+  `{atomP}` is `O,N;D1`. The previous behavior can be restored using by setting
+  the `symmetrizeConjugatedTerminalGroups` argument to false when calling
+  `GetBestRMS() and CalcRMS()` -->
+- `GetBestRMS()` と `CalcRMS()` は終端のカルボキシル基やニトロ基などの共役官能基を対称に取り扱うのがデフォルトになりました。例えば `C(=[O:1])[O-:2]` はどちらの方向にもマッチします。この変更で影響される官能基を表すSMARTSパターンは`[{atomP};$([{atomP}]-[*]=[{atomP}]),$([{atomP}]=[*]-[{atomP}])]~[*]` です（`{atomP}` は `O,N;D1`）。以前の挙動を再現するには`GetBestRMS()` と `CalcRMS()`を呼び出す際の引数で`symmetrizeConjugatedTerminalGroups`をfalseに設定してください。
+<!-- - The following `#defines` are no longer provided in/used by the C++ code or `RDConfig.h`:
+  - `BUILD_COORDGEN_SUPPORT`: use `RDK_BUILD_COORDGEN_SUPPORT` instead
+  - `RDK_THREADSAFE_SSS`: use `RDK_BUILD_THREADSAFE_SSS` instead
+  - `USE_BUILTIN_POPCOUNT`: use `RDK_OPTIMIZE_POPCNT` instead-->
+- 以下の定数はC++コードや`RDConfig.h`で今後提供・使用されません
+  - `BUILD_COORDGEN_SUPPORT`: 代わりに `RDK_BUILD_COORDGEN_SUPPORT` を使用してください
+  - `RDK_THREADSAFE_SSS`: 代わりに `RDK_BUILD_THREADSAFE_SSS` を使用してください
+  - `USE_BUILTIN_POPCOUNT`: 代わりに `RDK_OPTIMIZE_POPCNT` を使用してください
+<!--- The Python function `Chem.GetSSSR()` now returns the SSSR rings found instead of just returning the count of rings. This is consistent with `Chem.GetSymmSSSR()` and more useful.-->
+- Python関数 `Chem.GetSSSR()` は環の個数ではなく見つかったSSSR (訳注: smallest set of smallest rings) 環を返すようになりました。この挙動は `Chem.GetSymmSSSR()` と一貫性があり、より便利です。
+<!-- - The SMILES parser will ignore the value of `SmilesParserParams.useLegacyStereo` unless it is set to `false`. See the deprecation note about `useLegacyStereo` below for more information.-->
+- SMILES パーサーが `SmilesParserParams.useLegacyStereo` の値を無視するようになりました（ `false`に設定されている場合を除く）。詳細は `useLegacyStereo` の非推奨に関する下の記述をご覧ください。
+<!-- - The CFFI function `set_2d_coords_aligned()` now takes an additional `char **match_json` parameter; if `match_json` is not not `NULL`, `*match_json` will point to a JSON string containing the atoms and bonds which are part of the match.  It is up to the user to free this string.-->
+- CFFI関数 `set_2d_coords_aligned()` が追加のパラメータ `char **match_json` を取るようになりました。`match_json` が `NULL` ではない場合、`*match_json` はマッチ部分の原子と結合を含むJSON文字列を指します。この文字列のメモリを解放するのはユーザーの責任です。
+<!-- - The aliphatic imine rule used in tautomer enumeration has been changed to more
+  closely match the definition in the original paper.-->
+- 互変異性体の列挙に用いる脂肪族イミンに関する規則がより原論文の定義に近いものになりました。
+
+<!-- ## Bug Fixes: & ## Cleanup work: & New Features and Enhancements: -->
+### バグ修正・クリーンアップ・新機能及び改善
+<!-- 量が多すぎるため、各コミットの詳細を知りたい人は原文を読めるだろうという判断により省略 -->
+（訳注: 省略します。興味のある方は[原文](https://github.com/rdkit/rdkit/releases/tag/Release_2022_09_1)をご確認ください。）
+
+<!-- ## Code removed in this release: -->
+### このリリースで削除されたコード
+<!-- - The C++ class `RDLog::BlockLogs` has been removed. Please use the class `RDLog::LogStateSetter`. The Python class rdBase.BlockLogs() is still available and supported. -->
+- C++ クラス `RDLog::BlockLogs` は削除されました。クラス `RDLog::LogStateSetter` を使用してください。 Python クラス `rdBase.BlockLogs()` は現在もサポートされており使用可能です。
+<!-- - Python function `rdkit.Chem.WrapLogs()` has been removed. Please use `rdkit.rdBase.LogToPythonStderr()`. `rdkit.rdBase.WrapLogs()` also exists, but unless you need the old teeing behavior, prefer the former.-->
+- Python 関数 `rdkit.Chem.WrapLogs()` は削除されました。`rdkit.rdBase.LogToPythonStderr()` を使用してください。`rdkit.rdBase.WrapLogs()` も存在しますが、標準エラー出力へ同時に出力する古い挙動が必要な場合を除いて前者が好ましいです。
+<!-- - Python function `rdkit.Chem.LogWarningMsg()` has been removed. Please use `rdkit.rdBase.LogWarningMsg()`.-->
+- Python 関数 `rdkit.Chem.LogWarningMsg()` は削除されました。`rdkit.rdBase.LogWarningMsg()` を使用してください。
+<!-- - Python function `rdkit.Chem.LogErrorMsg()` has been removed. Please use `rdkit.rdBase.LogErrorMsg()`.-->
+- Python 関数 `rdkit.Chem.LogErrorMsg()` は削除されました。`rdkit.rdBase.LogErrorMsg()` を使用してください。
+
+### 非推奨となったコード（将来のリリースで削除予定）
+<!-- - The `SmilesParserParams` option `useLegacyStereo` is deprecated and will be removed in the 2023.03 release. Please use `SetUseLegacyStereoPerception()` instead. In the meantime the SMILES parser will use only use the value of `SmilesParserParams.useLegacyStereo` if it is set to `false`, otherwise the value of the global `useLegacyStereoPerception` parameter will control the behavior of the SMILES parser.-->
+- `SmilesParserParams` の `useLegacyStereo` オプションは非推奨となり、2023.03 のリリースで削除されます。代わりに `SetUseLegacyStereoPerception()` を使用してください。次のリリースまでの間、SMILES パーサーが `SmilesParserParams.useLegacyStereo` の値を使用するのは その値が `false` に設定されている場合だけです。それ以外の場合はグローバルパラメータ `useLegacyStereoPerception` の値が SMILES パーサーの挙動を指定します。
+<!-- - The following JS methods: -->
+- 以下のJavaScriptメソッド
+  * generate_aligned_coords()
+  * get_morgan_fp()
+  * get_morgan_fp_as_uint8array()
+  * get_pattern_fp()
+  * get_pattern_fp_as_uint8array()
+  <!-- which used to take several individual parameters now take a single JSON string parameter.  The overloads taking several individual parameters are now deprecated and will be removed in a future release. -->
+  は複数の個別パラメータを取っていましたが、今後は一つのJSON文字列パラメータを取るようになります。複数の個別パラメータによるオーバーロードは非推奨となり、将来のリリースで削除される予定です。
+<!--- The `PrintAsBase64PNGString` function in `PandasTools` is deprecated and replaced by `PrintAsImageString`, which has a more appropriate name given it actually supports both PNG and SVG images. -->
+- `PandasTools` 内の `PrintAsBase64PNGString` 関数は非推奨となり、PNGとSVGの両方をサポートすることを示すより適切な名前である `PrintAsImageString` に置き換えられました。
+
+## 新機能のコード例
+作業中

--- a/docs/release-2022-09-1.md
+++ b/docs/release-2022-09-1.md
@@ -2,81 +2,50 @@
 2022年10月21日に RDKit 2022.09.1 がリリースされました。この記事では新バージョンのリリースノートの抄訳と新機能のコード例を紹介します。より詳細な情報を知りたい方はリリースノートの原文 ([2022_09_1 (Q3 2022) Release](https://github.com/rdkit/rdkit/releases/tag/Release_2022_09_1)) をご確認ください。
 
 ## リリースノート抄訳
-<!-- ## Highlights -->
 ### ハイライト
-<!-- - The new RegistrationHash module provides one of the last pieces required to build a registration system with the RDKit. -->
 - RDKitで分子登録システムを構築するために必要な`RegistrationHash`モジュールが追加されました。
-<!-- This release includes an initial version of a C++ implementation of the xyz2mol algorithm for assigning bonds and bond orders based on atomic positions. This work was done as part of the 2022 Google Summer of Code. -->
 - 原子の位置から結合と結合次数を決めるxyz2molアルゴリズムのC++実装の初期バージョンが追加されました。これは2022年のGoogle Summer of Codeの成果です。
-<!-- A collection of new functionality has been added to minimallib and is now accessible from JavaScript and other programming languages. -->
 - minimallibに複数の新機能が追加され、JavaScript等の言語から使用可能になりました。
 
-<!-- ## Backwards incompatible changes -->
 ### 後方互換性のない変更
-<!-- Changes to the way atomic chirality is used in the canonicalization algorithm mean that canonical atom ranking and canonical SMILES generated with this RDKit version can be different from those generated with previous versions -->
 - カノニカル化アルゴリズムにおける原子のキラリティーの扱いが変更されため、このRDKitバージョンで生成されるカノニカル原子順位やカノニカルSMILESは以前のバージョンで生成されたものと異なる可能性があります。
-<!-- - `GetBestRMS() and CalcRMS()` by default now treat terminal conjugated functional groups like carboxylate and nitro symmetrically. For example, the group `C(=[O:1])[O-:2]` can match in either orientation. The SMARTS pattern which is used to recognize affected groups is: 
-  `[{atomP};$([{atomP}]-[*]=[{atomP}]),$([{atomP}]=[*]-[{atomP}])]~[*]` where
-  `{atomP}` is `O,N;D1`. The previous behavior can be restored using by setting
-  the `symmetrizeConjugatedTerminalGroups` argument to false when calling
-  `GetBestRMS() and CalcRMS()` -->
-- `GetBestRMS()` と `CalcRMS()` は終端のカルボキシラートアニオンやニトロ基などの共役官能基を対称に取り扱うのがデフォルトになりました。例えば `C(=[O:1])[O-:2]` はどちらの方向にもマッチします。この変更で影響される官能基を表すSMARTSパターンは`[{atomP};$([{atomP}]-[*]=[{atomP}]),$([{atomP}]=[*]-[{atomP}])]~[*]` です（`{atomP}` は `O,N;D1`）。以前の挙動を再現するには`GetBestRMS()` と `CalcRMS()`を呼び出す際の引数で`symmetrizeConjugatedTerminalGroups`をfalseに設定してください。
-<!-- - The following `#defines` are no longer provided in/used by the C++ code or `RDConfig.h`:
-  - `BUILD_COORDGEN_SUPPORT`: use `RDK_BUILD_COORDGEN_SUPPORT` instead
-  - `RDK_THREADSAFE_SSS`: use `RDK_BUILD_THREADSAFE_SSS` instead
-  - `USE_BUILTIN_POPCOUNT`: use `RDK_OPTIMIZE_POPCNT` instead-->
+- `GetBestRMS()` と `CalcRMS()` は終端のカルボキシラートアニオンやニトロ基などの共役官能基を対称に取り扱うのがデフォルトになりました。例えば `C(=[O:1])[O-:2]` はどちらの方向にもマッチします。この変更で影響される官能基を表すSMARTSパターンは`[{atomP};$([{atomP}]-[*]=[{atomP}]),$([{atomP}]=[*]-[{atomP}])]~[*]` です（`{atomP}` は `O,N;D1`）。以前の挙動を再現するには`GetBestRMS()` や `CalcRMS()`を呼び出す際の引数で`symmetrizeConjugatedTerminalGroups`をfalseに設定してください。
 - 以下の定数はC++コードや`RDConfig.h`で今後提供・使用されません
   - `BUILD_COORDGEN_SUPPORT`: 代わりに `RDK_BUILD_COORDGEN_SUPPORT` を使用してください
   - `RDK_THREADSAFE_SSS`: 代わりに `RDK_BUILD_THREADSAFE_SSS` を使用してください
   - `USE_BUILTIN_POPCOUNT`: 代わりに `RDK_OPTIMIZE_POPCNT` を使用してください
-<!--- The Python function `Chem.GetSSSR()` now returns the SSSR rings found instead of just returning the count of rings. This is consistent with `Chem.GetSymmSSSR()` and more useful.-->
 - Python関数 `Chem.GetSSSR()` は環の個数ではなく見つかったSSSR (訳注: smallest set of smallest rings) 環を返すようになりました。この挙動は `Chem.GetSymmSSSR()` と一貫性があり、より便利です。
-<!-- - The SMILES parser will ignore the value of `SmilesParserParams.useLegacyStereo` unless it is set to `false`. See the deprecation note about `useLegacyStereo` below for more information.-->
 - SMILES パーサーが `SmilesParserParams.useLegacyStereo` の値を無視するようになりました（ `false`に設定されている場合を除く）。詳細は `useLegacyStereo` の非推奨に関する下の記述をご覧ください。
-<!-- - The CFFI function `set_2d_coords_aligned()` now takes an additional `char **match_json` parameter; if `match_json` is not not `NULL`, `*match_json` will point to a JSON string containing the atoms and bonds which are part of the match.  It is up to the user to free this string.-->
 - CFFI関数 `set_2d_coords_aligned()` が追加のパラメータ `char **match_json` を取るようになりました。`match_json` が `NULL` ではない場合、`*match_json` はマッチ部分の原子と結合を含むJSON文字列を指します。この文字列のメモリ解放はユーザーが行う必要があります。
-<!-- - The aliphatic imine rule used in tautomer enumeration has been changed to more
-  closely match the definition in the original paper.-->
 - 互変異性体の列挙に用いる脂肪族イミンに関する規則がより原論文の定義に近いものになりました。
 
-<!-- ## Bug Fixes: & ## Cleanup work: & New Features and Enhancements: -->
 ### バグ修正・クリーンアップ・新機能及び改善
-<!-- 量が多すぎるため、各コミットの詳細を知りたい人は原文を読めるだろうという判断により省略 -->
-（訳注: 省略します。興味のある方は[原文](https://github.com/rdkit/rdkit/releases/tag/Release_2022_09_1)をご確認ください。）
+（訳注: 省略します。ご興味のある方は[原文](https://github.com/rdkit/rdkit/releases/tag/Release_2022_09_1)をご確認ください。）
 
-<!-- ## Code removed in this release: -->
 ### このリリースで削除されたコード
-<!-- - The C++ class `RDLog::BlockLogs` has been removed. Please use the class `RDLog::LogStateSetter`. The Python class rdBase.BlockLogs() is still available and supported. -->
 - C++ クラス `RDLog::BlockLogs` は削除されました。クラス `RDLog::LogStateSetter` を使用してください。 Python クラス `rdBase.BlockLogs()` は現在もサポートされており使用可能です。
-<!-- - Python function `rdkit.Chem.WrapLogs()` has been removed. Please use `rdkit.rdBase.LogToPythonStderr()`. `rdkit.rdBase.WrapLogs()` also exists, but unless you need the old teeing behavior, prefer the former.-->
 - Python 関数 `rdkit.Chem.WrapLogs()` は削除されました。`rdkit.rdBase.LogToPythonStderr()` を使用してください。`rdkit.rdBase.WrapLogs()` も存在しますが、標準エラー出力へ同時に出力する古い挙動が必要な場合を除いて前者が好ましいです。
-<!-- - Python function `rdkit.Chem.LogWarningMsg()` has been removed. Please use `rdkit.rdBase.LogWarningMsg()`.-->
 - Python 関数 `rdkit.Chem.LogWarningMsg()` は削除されました。`rdkit.rdBase.LogWarningMsg()` を使用してください。
-<!-- - Python function `rdkit.Chem.LogErrorMsg()` has been removed. Please use `rdkit.rdBase.LogErrorMsg()`.-->
 - Python 関数 `rdkit.Chem.LogErrorMsg()` は削除されました。`rdkit.rdBase.LogErrorMsg()` を使用してください。
 
 ### 非推奨となったコード（将来のリリースで削除予定）
-<!-- - The `SmilesParserParams` option `useLegacyStereo` is deprecated and will be removed in the 2023.03 release. Please use `SetUseLegacyStereoPerception()` instead. In the meantime the SMILES parser will use only use the value of `SmilesParserParams.useLegacyStereo` if it is set to `false`, otherwise the value of the global `useLegacyStereoPerception` parameter will control the behavior of the SMILES parser.-->
 - `SmilesParserParams` の `useLegacyStereo` オプションは非推奨となり、2023.03 のリリースで削除されます。代わりに `SetUseLegacyStereoPerception()` を使用してください。次のリリースまでの間、SMILES パーサーが `SmilesParserParams.useLegacyStereo` の値を使用するのは その値が `false` に設定されている場合だけです。それ以外の場合はグローバルパラメータ `useLegacyStereoPerception` の値が SMILES パーサーの挙動を指定します。
-<!-- - The following JS methods: -->
 - 以下のJavaScriptメソッド
   * generate_aligned_coords()
   * get_morgan_fp()
   * get_morgan_fp_as_uint8array()
   * get_pattern_fp()
   * get_pattern_fp_as_uint8array()
-  <!-- which used to take several individual parameters now take a single JSON string parameter.  The overloads taking several individual parameters are now deprecated and will be removed in a future release. -->
   は複数の個別パラメータを取っていましたが、今後は一つのJSON文字列パラメータを取るようになります。複数の個別パラメータによるオーバーロードは非推奨となり、将来のリリースで削除される予定です。
-<!--- The `PrintAsBase64PNGString` function in `PandasTools` is deprecated and replaced by `PrintAsImageString`, which has a more appropriate name given it actually supports both PNG and SVG images. -->
 - `PandasTools` 内の `PrintAsBase64PNGString` 関数は非推奨となり、PNGとSVGの両方をサポートすることを示すより適切な名前である `PrintAsImageString` に置き換えられました。
 
 ## 新機能詳細
 ここでは新機能の詳細を紹介します。
 
 ### xyz2mol
-xyz2molはXYZ形式のファイルをRDKitのmoleculeオブジェクトとして読み込む機能です。この機能は [(Kim, 2015)](https://doi.org/10.1002/bkcs.10334) で提案された手法の[Jan Jensen氏による実装](https://github.com/jensengroup/xyz2mol)を取り込んだものになります（[Pull Request](https://github.com/rdkit/rdkit/pull/5557)）。コードやドキュメントは [Code/GraphMol/DetermineBonds](https://github.com/rdkit/rdkit/tree/Release_2022_09/Code/GraphMol/DetermineBonds) にあります。
+xyz2molはXYZ形式のファイルをRDKitのmoleculeオブジェクトとして読み込む機能です。この機能は [(Kim, 2015)](https://doi.org/10.1002/bkcs.10334) で提案された手法の [Jan Jensen氏による実装](https://github.com/jensengroup/xyz2mol) を取り込んだものになります（[Pull Request](https://github.com/rdkit/rdkit/pull/5557)）。コードやドキュメントは [Code/GraphMol/DetermineBonds](https://github.com/rdkit/rdkit/tree/Release_2022_09/Code/GraphMol/DetermineBonds) にあります。
 
-[テストコード](https://github.com/rdkit/rdkit/blob/Release_2022_09/Code/GraphMol/DetermineBonds/Wrap/testDetermineBonds.py)を参考に、Pythonでxyz2molを使う例を以下に示します。コード中の`test10.xyz`は[test_data/connectivity](https://github.com/rdkit/rdkit/tree/Release_2022_09/Code/GraphMol/DetermineBonds/test_data/connectivity)からダウンロードしたものです。
+Pythonでxyz2molを使う例を以下に示します。コード中の `test10.xyz` は [test_data/connectivity](https://github.com/rdkit/rdkit/tree/Release_2022_09/Code/GraphMol/DetermineBonds/test_data/connectivity) からダウンロードしたものです。ドキュメントが見当たらなかったため、[テストコード](https://github.com/rdkit/rdkit/blob/Release_2022_09/Code/GraphMol/DetermineBonds/Wrap/testDetermineBonds.py)を参考にしました。
 
 ```python
 from rdkit import Chem
@@ -85,41 +54,48 @@ from rdkit.Chem import rdDetermineBonds
 # XYZファイルの読み込み
 # XYZを読み込んだ時点では結合が存在しません
 mol = Chem.MolFromXYZFile("test10.xyz")
-print(Chem.MolToSmiles(mol))  # 'C.C.C.C.N.[HH].[HH].[HH].[HH].[HH].[HH].[HH].[HH].[HH]'
+print(Chem.MolToSmiles(mol))
+# 'C.C.C.C.N.[HH].[HH].[HH].[HH].[HH].[HH].[HH].[HH].[HH]'
 
 # 結合の予測
 rdDetermineBonds.DetermineBonds(mol)
-print(Chem.MolToSmiles(mol))  # [H]C([H])=C(N([H])[H])C([H])([H])C([H])([H])[H]
+print(Chem.MolToSmiles(mol))
+# [H]C([H])=C(N([H])[H])C([H])([H])C([H])([H])[H]
 
 # 結合の有無のみ予測
 rdDetermineBonds.DetermineConnectivity(mol)
-print(Chem.MolToSmiles(mol))  # [H]C([H])C(N([H])[H])C([H])([H])C([H])([H])[H]
+print(Chem.MolToSmiles(mol))
+# [H]C([H])C(N([H])[H])C([H])([H])C([H])([H])[H]
 
 # 結合次数の予測
 rdDetermineBonds.DetermineBondOrders(mol)
-print(Chem.MolToSmiles(mol))  # [H]C([H])=C(N([H])[H])C([H])([H])C([H])([H])[H]
+print(Chem.MolToSmiles(mol))
+# [H]C([H])=C(N([H])[H])C([H])([H])C([H])([H])[H]
 ```
 
-なお、執筆時点 (2022/10/30) では筆者の環境でRDKitをPyPI経由でインストールすると`rdDetermineBonds`のインポートに失敗しました。
+なお、執筆時点 (2022/10/30) では筆者の環境でRDKitをPyPI経由でインストールすると`rdDetermineBonds`のインポートに失敗したため、このコードはAnacondaでインストールしたRDKitで検証しました。
 
-`DetermineBonds()`は現在の結合を破棄し、原子座標を元に原子間結合を割り当てる関数です。以下の引数があります。
+#### 各関数の解説
+[DetermineBonds.h](https://github.com/rdkit/rdkit/blob/Release_2022_09/Code/GraphMol/DetermineBonds/DetermineBonds.h) のコメントの翻訳です。
+
+`DetermineBonds()` は現在の結合を破棄し、原子座標を元に原子間結合を割り当てる関数です。`embedChiral` を `True` に設定しないでこの関数を呼び出した場合には分子をサニタイズすることが推奨されます。以下の引数があります。以下の引数があります。
 
 - `mol` (RWMol): 対象となる分子。3次元構造を持つ必要がある
-- `useHueckel` (bool, optional)`: `True` にすると結合予測にファン・デル・ワールス法ではなく拡張ヒュッケル法が用いられる。デフォルトは `False`
-- `charge` (int, optional): 分子の電荷。電荷が非ゼロのときに指定する必要がある。デフォルトは`0`
+- `useHueckel` (bool, optional): `True` にすると結合予測にファン・デル・ワールス法ではなく拡張ヒュッケル法が用いられる。デフォルトは `False`
+- `charge` (int, optional): 分子の電荷。電荷が非ゼロのときに指定する必要がある。デフォルトは `0`
 - `covFactor` (double, optional): ファン・デル・ワールス法を用いる場合に各共有結合半径に掛けられる係数。デフォルトは `1.3`
 - `allowChargedFragments` (bool, optional): `True` にすると原子価に応じた形式電荷が原子に置かれます。`False`にすると原子にラジカル電荷が置かれます。デフォルトは `True`
 - `embedChiral` (bool, optional): `True` にすると分子にキラリティの情報が埋め込まれます。この引数が`True`の場合、この関数は `sanitizeMol()` を呼び出します。デフォルトは `True`
 - `useAtomMap` (bool, optional): `True` にすると分子の原子マップが生成されます。デフォルトは `False`
 
-`DetermineConnectivity()`は現在の結合を破棄し、原子座標を元に原子間結合を割り当てる関数です。結合次数の予測を行わない点が`DetermineBonds()`と異なります。以下の引数があります。
+`DetermineConnectivity()` は現在の結合を破棄し、原子座標を元に原子間結合を割り当てる関数です。結合次数の予測を行わない点が `DetermineBonds()` と異なります。以下の引数があります。
 
 - `mol` (RWMol): 対象となる分子。3次元構造を持つ必要がある
-- `useHueckel` (bool, optional)`: `True` にすると結合予測にファン・デル・ワールス法ではなく拡張ヒュッケル法が用いられる。デフォルトは `False`
+- `useHueckel` (bool, optional): `True` にすると結合予測にファン・デル・ワールス法ではなく拡張ヒュッケル法が用いられる。デフォルトは `False`
 - `charge` (int, optional): 分子の電荷。ヒュッケル法を使用する場合で電荷が非ゼロのときに指定する必要がある。デフォルトは `0`
 - `covFactor` (double, optional): ファン・デル・ワールス法を用いる場合に各共有結合半径に掛けられる係数。デフォルトは `1.3`
 
-`DetermineBondOrders()`は原子間結合が定義された分子に結合次数を割り当てる関数です。`embedChiral`を`True`にしないでこの関数を呼び出した場合には分子をサニタイズすることが推奨されます。以下の引数があります。
+`DetermineBondOrders()` は原子間結合が定義された分子に結合次数を割り当てる関数です。`embedChiral` を `True` に設定しないでこの関数を呼び出した場合には分子をサニタイズすることが推奨されます。以下の引数があります。
 
 - `mol` (RWMol): 対象となる分子。原子間結合に対応する単結合を持つ必要がある
 - `charge` (int, optional): 分子の電荷。電荷が非ゼロのときに指定する必要がある。デフォルトは `0`
@@ -128,7 +104,7 @@ print(Chem.MolToSmiles(mol))  # [H]C([H])=C(N([H])[H])C([H])([H])C([H])([H])[H]
 - `useAtomMap` (bool, optional): `True` にすると分子の原子マップが生成されます。デフォルトは `False`
 
 ### RegistrationHash
-RegistrationHashはSchrödinger社が分子の重複を防ぐために使っている関数をオープンソース化したものです。[UGM 2022でのLightning talk](https://github.com/rdkit/UGM_2022/blob/main/Presentations/nealschneider_introducing_registrationhash_lightning.pdf)で概要が説明されています。
+RegistrationHash は Schrödinger 社が分子の重複を防ぐために使っている関数をオープンソース化したものです。[UGM 2022でのLightning talk](https://github.com/rdkit/UGM_2022/blob/main/Presentations/nealschneider_introducing_registrationhash_lightning.pdf) で概要が説明されています。
 
 [ドキュメント](https://www.rdkit.org/docs/source/rdkit.Chem.RegistrationHash.html)によると、SMILESに比べて以下の点が優れているそうです。
 
@@ -138,7 +114,7 @@ RegistrationHashはSchrödinger社が分子の重複を防ぐために使って�
 
 基本的な使い方は以下の通りです。
 
-```
+```python
 from rdkit import Chem
 from rdkit.Chem import RegistrationHash
 
@@ -155,4 +131,4 @@ print(hash)  # 48b5d33cd3a5b7f859dad34ab19cdab3b8dd6cf3
 - `TAUTOMER_INSENSITIVE_LAYERS`: 互変異性体に関するレイヤーを除く
 
 
-以上です。ドキュメントの誤りや改善点を見つけた場合はユーザー会のSlackか[GitHub](https://github.com/rdkit-users-jp/rdkit-users-jp.github.io)にご連絡ください。
+以上です。ドキュメントの誤りや改善点を見つけた場合はユーザー会のSlackか[GitHub](https://github.com/rdkit-users-jp/rdkit-users-jp.github.io)までご連絡ください。

--- a/docs/release-2022-09-1.md
+++ b/docs/release-2022-09-1.md
@@ -20,7 +20,7 @@
   `{atomP}` is `O,N;D1`. The previous behavior can be restored using by setting
   the `symmetrizeConjugatedTerminalGroups` argument to false when calling
   `GetBestRMS() and CalcRMS()` -->
-- `GetBestRMS()` と `CalcRMS()` は終端のカルボキシル基やニトロ基などの共役官能基を対称に取り扱うのがデフォルトになりました。例えば `C(=[O:1])[O-:2]` はどちらの方向にもマッチします。この変更で影響される官能基を表すSMARTSパターンは`[{atomP};$([{atomP}]-[*]=[{atomP}]),$([{atomP}]=[*]-[{atomP}])]~[*]` です（`{atomP}` は `O,N;D1`）。以前の挙動を再現するには`GetBestRMS()` と `CalcRMS()`を呼び出す際の引数で`symmetrizeConjugatedTerminalGroups`をfalseに設定してください。
+- `GetBestRMS()` と `CalcRMS()` は終端のカルボキシラートアニオンやニトロ基などの共役官能基を対称に取り扱うのがデフォルトになりました。例えば `C(=[O:1])[O-:2]` はどちらの方向にもマッチします。この変更で影響される官能基を表すSMARTSパターンは`[{atomP};$([{atomP}]-[*]=[{atomP}]),$([{atomP}]=[*]-[{atomP}])]~[*]` です（`{atomP}` は `O,N;D1`）。以前の挙動を再現するには`GetBestRMS()` と `CalcRMS()`を呼び出す際の引数で`symmetrizeConjugatedTerminalGroups`をfalseに設定してください。
 <!-- - The following `#defines` are no longer provided in/used by the C++ code or `RDConfig.h`:
   - `BUILD_COORDGEN_SUPPORT`: use `RDK_BUILD_COORDGEN_SUPPORT` instead
   - `RDK_THREADSAFE_SSS`: use `RDK_BUILD_THREADSAFE_SSS` instead
@@ -34,7 +34,7 @@
 <!-- - The SMILES parser will ignore the value of `SmilesParserParams.useLegacyStereo` unless it is set to `false`. See the deprecation note about `useLegacyStereo` below for more information.-->
 - SMILES パーサーが `SmilesParserParams.useLegacyStereo` の値を無視するようになりました（ `false`に設定されている場合を除く）。詳細は `useLegacyStereo` の非推奨に関する下の記述をご覧ください。
 <!-- - The CFFI function `set_2d_coords_aligned()` now takes an additional `char **match_json` parameter; if `match_json` is not not `NULL`, `*match_json` will point to a JSON string containing the atoms and bonds which are part of the match.  It is up to the user to free this string.-->
-- CFFI関数 `set_2d_coords_aligned()` が追加のパラメータ `char **match_json` を取るようになりました。`match_json` が `NULL` ではない場合、`*match_json` はマッチ部分の原子と結合を含むJSON文字列を指します。この文字列のメモリを解放するのはユーザーの責任です。
+- CFFI関数 `set_2d_coords_aligned()` が追加のパラメータ `char **match_json` を取るようになりました。`match_json` が `NULL` ではない場合、`*match_json` はマッチ部分の原子と結合を含むJSON文字列を指します。この文字列のメモリ解放はユーザーが行う必要があります。
 <!-- - The aliphatic imine rule used in tautomer enumeration has been changed to more
   closely match the definition in the original paper.-->
 - 互変異性体の列挙に用いる脂肪族イミンに関する規則がより原論文の定義に近いものになりました。
@@ -70,5 +70,89 @@
 <!--- The `PrintAsBase64PNGString` function in `PandasTools` is deprecated and replaced by `PrintAsImageString`, which has a more appropriate name given it actually supports both PNG and SVG images. -->
 - `PandasTools` 内の `PrintAsBase64PNGString` 関数は非推奨となり、PNGとSVGの両方をサポートすることを示すより適切な名前である `PrintAsImageString` に置き換えられました。
 
-## 新機能のコード例
-作業中
+## 新機能詳細
+ここでは新機能の詳細を紹介します。
+
+### xyz2mol
+xyz2molはXYZ形式のファイルをRDKitのmoleculeオブジェクトとして読み込む機能です。この機能は [(Kim, 2015)](https://doi.org/10.1002/bkcs.10334) で提案された手法の[Jan Jensen氏による実装](https://github.com/jensengroup/xyz2mol)を取り込んだものになります（[Pull Request](https://github.com/rdkit/rdkit/pull/5557)）。コードやドキュメントは [Code/GraphMol/DetermineBonds](https://github.com/rdkit/rdkit/tree/Release_2022_09/Code/GraphMol/DetermineBonds) にあります。
+
+[テストコード](https://github.com/rdkit/rdkit/blob/Release_2022_09/Code/GraphMol/DetermineBonds/Wrap/testDetermineBonds.py)を参考に、Pythonでxyz2molを使う例を以下に示します。コード中の`test10.xyz`は[test_data/connectivity](https://github.com/rdkit/rdkit/tree/Release_2022_09/Code/GraphMol/DetermineBonds/test_data/connectivity)からダウンロードしたものです。
+
+```python
+from rdkit import Chem
+from rdkit.Chem import rdDetermineBonds
+
+# XYZファイルの読み込み
+# XYZを読み込んだ時点では結合が存在しません
+mol = Chem.MolFromXYZFile("test10.xyz")
+print(Chem.MolToSmiles(mol))  # 'C.C.C.C.N.[HH].[HH].[HH].[HH].[HH].[HH].[HH].[HH].[HH]'
+
+# 結合の予測
+rdDetermineBonds.DetermineBonds(mol)
+print(Chem.MolToSmiles(mol))  # [H]C([H])=C(N([H])[H])C([H])([H])C([H])([H])[H]
+
+# 結合の有無のみ予測
+rdDetermineBonds.DetermineConnectivity(mol)
+print(Chem.MolToSmiles(mol))  # [H]C([H])C(N([H])[H])C([H])([H])C([H])([H])[H]
+
+# 結合次数の予測
+rdDetermineBonds.DetermineBondOrders(mol)
+print(Chem.MolToSmiles(mol))  # [H]C([H])=C(N([H])[H])C([H])([H])C([H])([H])[H]
+```
+
+なお、執筆時点 (2022/10/30) では筆者の環境でRDKitをPyPI経由でインストールすると`rdDetermineBonds`のインポートに失敗しました。
+
+`DetermineBonds()`は現在の結合を破棄し、原子座標を元に原子間結合を割り当てる関数です。以下の引数があります。
+
+- `mol` (RWMol): 対象となる分子。3次元構造を持つ必要がある
+- `useHueckel` (bool, optional)`: `True` にすると結合予測にファン・デル・ワールス法ではなく拡張ヒュッケル法が用いられる。デフォルトは `False`
+- `charge` (int, optional): 分子の電荷。電荷が非ゼロのときに指定する必要がある。デフォルトは`0`
+- `covFactor` (double, optional): ファン・デル・ワールス法を用いる場合に各共有結合半径に掛けられる係数。デフォルトは `1.3`
+- `allowChargedFragments` (bool, optional): `True` にすると原子価に応じた形式電荷が原子に置かれます。`False`にすると原子にラジカル電荷が置かれます。デフォルトは `True`
+- `embedChiral` (bool, optional): `True` にすると分子にキラリティの情報が埋め込まれます。この引数が`True`の場合、この関数は `sanitizeMol()` を呼び出します。デフォルトは `True`
+- `useAtomMap` (bool, optional): `True` にすると分子の原子マップが生成されます。デフォルトは `False`
+
+`DetermineConnectivity()`は現在の結合を破棄し、原子座標を元に原子間結合を割り当てる関数です。結合次数の予測を行わない点が`DetermineBonds()`と異なります。以下の引数があります。
+
+- `mol` (RWMol): 対象となる分子。3次元構造を持つ必要がある
+- `useHueckel` (bool, optional)`: `True` にすると結合予測にファン・デル・ワールス法ではなく拡張ヒュッケル法が用いられる。デフォルトは `False`
+- `charge` (int, optional): 分子の電荷。ヒュッケル法を使用する場合で電荷が非ゼロのときに指定する必要がある。デフォルトは `0`
+- `covFactor` (double, optional): ファン・デル・ワールス法を用いる場合に各共有結合半径に掛けられる係数。デフォルトは `1.3`
+
+`DetermineBondOrders()`は原子間結合が定義された分子に結合次数を割り当てる関数です。`embedChiral`を`True`にしないでこの関数を呼び出した場合には分子をサニタイズすることが推奨されます。以下の引数があります。
+
+- `mol` (RWMol): 対象となる分子。原子間結合に対応する単結合を持つ必要がある
+- `charge` (int, optional): 分子の電荷。電荷が非ゼロのときに指定する必要がある。デフォルトは `0`
+- `allowChargedFragments` (bool, optional): `True` にすると原子価に応じた形式電荷が原子に置かれます。`False`にすると原子にラジカル電荷が置かれます。デフォルトは `True`
+- `embedChiral` (bool, optional): `True` にすると分子にキラリティの情報が埋め込まれます。この引数が`True`の場合、この関数は `sanitizeMol()` を呼び出します。デフォルトは `True`
+- `useAtomMap` (bool, optional): `True` にすると分子の原子マップが生成されます。デフォルトは `False`
+
+### RegistrationHash
+RegistrationHashはSchrödinger社が分子の重複を防ぐために使っている関数をオープンソース化したものです。[UGM 2022でのLightning talk](https://github.com/rdkit/UGM_2022/blob/main/Presentations/nealschneider_introducing_registrationhash_lightning.pdf)で概要が説明されています。
+
+[ドキュメント](https://www.rdkit.org/docs/source/rdkit.Chem.RegistrationHash.html)によると、SMILESに比べて以下の点が優れているそうです。
+
+- 化学的に意味のないSMILESの特徴を無視している（例: 原子マップ番号）
+- より強化された立体化学のカノニカル化（例えば `C[C@H](O)CC |&1:1|` と `C[C@@H](O)CC |&1:1|` が同じハッシュ値になる）
+- S group のカノニカル化（例: ポリマーデータ）
+
+基本的な使い方は以下の通りです。
+
+```
+from rdkit import Chem
+from rdkit.Chem import RegistrationHash
+
+mol = Chem.MolFromSmiles('CNCC(=O)OC')
+scheme = RegistrationHash.HashScheme.ALL_LAYERS
+hash = RegistrationHash.GetMolHash(RegistrationHash.GetMolLayers(mol), scheme)
+print(hash)  # 48b5d33cd3a5b7f859dad34ab19cdab3b8dd6cf3
+```
+
+`scheme` には以下の三種類を指定することができます。
+
+- `ALL_LAYERS`: 全レイヤーを用いた最も厳格なハッシュスキーム
+- `STEREO_INSENSITIVE_LAYERS`: 立体化学に関するレイヤーを除く
+- `TAUTOMER_INSENSITIVE_LAYERS`: 互変異性体に関するレイヤーを除く
+
+
+以上です。ドキュメントの誤りや改善点を見つけた場合はユーザー会のSlackか[GitHub](https://github.com/rdkit-users-jp/rdkit-users-jp.github.io)にご連絡ください。


### PR DESCRIPTION
このPull requestはRDKit 日本ユーザー会のWebサイトに [RDKIt 2022.09.1 のリリースノート](https://github.com/rdkit/rdkit/releases/tag/Release_2022_09_1)の抄訳と、新機能のコード例を追加します。

以下は翻訳に迷った箇所のリストです。

- `registration system`: 登録システム（日本語でこれだけだと意味が通じないと思います）
- `assigning bonds and bond orders`: 結合と結合次数を決める（直訳だと「割り当てる」ですが、実際の意味としては 「予測する」が近そうなので適切な動詞に迷っています）
- `canonicalization algorithm`: カノニカル化アルゴリズム (canonicalizationを辞書で引くと「標準化」や「正規化」が出てきますが、これでは統計学の用語と被るのでケモインフォ分野で先例があった「カノニカル化」としました cf. [株式会社モルシルのドキュメント](https://www.molsis.co.jp/wp-content/themes/molsis/pdf/daylight_201201.pdf)）
- `canonical atom ranking`: カノニカル原子順位（これもcanonicalの訳に迷っています）
- `carboxylate`: カルボキシラートアニオン（この文脈では官能基を話題にしており、[元となったPR](https://github.com/rdkit/rdkit/pull/5322)でも `CCC(=O)[O-]` が例に挙げられているため、「アニオン」としました。）
- `free this string`: 文字列のメモリを解放（ここでfreeはメモリ解放の意味で使われていると思いますが、これは意訳しすぎかもしれません）
- `old teeing behavior`: 標準エラー出力へ同時に出力する古い挙動（teeコマンドの挙動を一言で表す日本語の動詞がなさそうなので迷っています。[ドキュメント](https://www.rdkit.org/docs/source/rdkit.rdBase.html#rdkit.rdBase.WrapLogs)によると標準エラー出力にteeする関数のようなのでこう訳しました）